### PR TITLE
Fix logo redirection link

### DIFF
--- a/themes/pybr/templates/base.html
+++ b/themes/pybr/templates/base.html
@@ -84,7 +84,7 @@
             <div class="row">
               <div class="col-12">
                 <div class="header-container">
-                  <a href="{{ SITEURL }}/index">
+                  <a href="{{ SITEURL }}/index.html">
                     <img class="header-logo" src="{{ SITEURL }}/theme/img/site-logo.svg" title="{{ SITENAME }}" alt="{{ SITENAME }}"/>
                   </a>
 


### PR DESCRIPTION
O link anterior era "https://python.org.br/index" e dava: 404 Not Found. Testei por .html ao final e funcionou.